### PR TITLE
Rename windows-command to batch-command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Renamed `windows-command` to `batch-command` for consistency
+
 ## [1.0.0] - 2025-03-11
 
 Initial release

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Command line code blocks are identified using one of the following languages:
 
 | Name                 | Highlight    | Prompt Pattern | Default Prompt | Continuation |
 | -------------------- | ------------ | -------------- | -------------- | ------------ |
+| `batch-command`      | `batch`      | `/\S*?>/`      | `C:\>`         | `^`          |
 | `powershell-command` | `powershell` | `/\S*?>/`      | `PS>`          | `` ` ``      |
 | `shell-command`      | `shell`      | `/\S*?[#$%]/`  | `$`            | `\`          |
-| `windows-command`    | `batch`      | `/\S*?>/`      | `C:\>`         | `^`          |
 
 For example, copying the following code block to the clipboard will remove the
 prompt and output while preserving line continuations and white space:

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,12 @@ const DEFAULT_SETTINGS: Partial<CommandLineSettings> = {
     highlight: false,
     normalize: false,
     languages: {
+        "batch-command": {
+            defaultPrompt: "C:\\>",
+            promptPattern: "^\\S*?>\\s*",
+            continuationPattern: "\\^$",
+            alias: "batch",
+        },
         "powershell-command": {
             defaultPrompt: "PS>",
             promptPattern: "^\\S*?>\\s*",
@@ -45,12 +51,6 @@ const DEFAULT_SETTINGS: Partial<CommandLineSettings> = {
             promptPattern: "^\\S*?[#$%]\\s*",
             continuationPattern: "\\\\$",
             alias: "shell",
-        },
-        "windows-command": {
-            defaultPrompt: "C:\\>",
-            promptPattern: "^\\S*?>\\s*",
-            continuationPattern: "\\^$",
-            alias: "batch",
         },
     },
 };


### PR DESCRIPTION
This PR renames `windows-command` to `batch-command` for consistency with other languages.