### PR TITLE
Fix CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release
 
-[Unreleased]: https://github.com/sstallion/obsidian-command-line/compare/1.0.1...HEAD
-[1.0.1]: https://github.com/sstallion/obsidian-command-line/releases/tag/1.0.1
+[Unreleased]: https://github.com/sstallion/obsidian-command-line/compare/1.1.0...HEAD
+[1.1.0]: https://github.com/sstallion/obsidian-command-line/releases/tag/1.1.0
 [1.0.0]: https://github.com/sstallion/obsidian-command-line/releases/tag/1.0.0


### PR DESCRIPTION
This PR fixes incorrect CHANGELOG.md entries for the current release. This is what happens when you make changes before heading to bed early.