### PR TITLE
Remove unnecessary sleep function

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,6 @@
 *.*
+!*.css
 !*.json
 !*.mjs
-!*.scss
 !*.ts
 package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed unnecessary sleep function
+
 ## [1.1.0] - 2025-03-19
 
 ### Changed

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,7 +26,6 @@
 import { PluginSettingTab, Setting } from "obsidian";
 import { CommandLineContext } from "./command";
 import CommandLinePlugin from "./main";
-import * as util from "./util";
 
 const RELOAD_DELAY = 500;
 
@@ -62,7 +61,7 @@ export class CommandLineSettingsTab extends PluginSettingTab {
                     .onChange(async (value) => {
                         this.plugin.settings.highlight = value;
                         await this.plugin.saveSettings();
-                        await util.sleep(RELOAD_DELAY).then(() => {
+                        await sleep(RELOAD_DELAY).then(() => {
                             location.reload();
                         });
                     });

--- a/src/util.ts
+++ b/src/util.ts
@@ -44,10 +44,6 @@ export function mapTail<T>(array: T[], callbackFn: (thisArg: T) => T): T[] {
     }, [] as T[]);
 }
 
-export function sleep(delay: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, delay));
-}
-
 export function waitForGlobal(name: string, delay = 100): Promise<void> {
     return new Promise((resolve) => {
         (function resolver() {


### PR DESCRIPTION
This PR removes an unnecessary sleep function from util.ts in favor of a global sleep function provided by Obsidian.