### PR TITLE
Add command-line as an alternative to highlighted languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added `command-line` as an alternative to highlighted languages
+
 ## [1.1.1] - 2025-03-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Command line code blocks are identified using one of the following languages:
 
 | Name                 | Highlight    | Prompt Pattern | Default Prompt | Continuation |
 | -------------------- | ------------ | -------------- | -------------- | ------------ |
+| `command-line`       | N/A          | Any below      | `C:\>`         | Any below    |
 | `batch-command`      | `batch`      | `/\S*?>/`      | `C:\>`         | `^`          |
 | `powershell-command` | `powershell` | `/\S*?>/`      | `PS>`          | `` ` ``      |
 | `shell-command`      | `shell`      | `/\S*?[#$%]/`  | `$`            | `\`          |

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,11 @@ const DEFAULT_SETTINGS: Partial<CommandLineSettings> = {
     highlight: false,
     normalize: false,
     languages: {
+        "command-line": {
+            defaultPrompt: "C:\\>",
+            promptPattern: "^\\S*?[#$%>]\\s*",
+            continuationPattern: "[\\\\`^]$",
+        },
         "batch-command": {
             defaultPrompt: "C:\\>",
             promptPattern: "^\\S*?>\\s*",


### PR DESCRIPTION
This PR adds a generic `command-line` language, which is a superset of prompt and continuation patterns of all supported languages that provides no highlighting. This seems to be the simplest way to support those who prefer Prism styling without language-specific highlighting.

This will likely irk some users, but the default prompt for command-line was chosen based on most shell documentation includes prompts, however Microsoft's style guidelines do not. This should hopefully strike a balance with existing documentation and needing to add additional checks to disable styling if no prompt is present.

Closes #5